### PR TITLE
Change config FTP default to FALSE. Set backup params in cron.php. Add CRON constant to wrapping 'if' statement

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -56,7 +56,7 @@ $config['backup']['db_backup_prefs'] = array(
 				);
 
 // allow FTP backup
-$config['backup']['allow_ftp'] = TRUE;
+$config['backup']['allow_ftp'] = FALSE; //if TRUE and ftp fails then script halts and emails etc are not sent out..
 
 // FTP backup preferences
 $config['backup']['ftp_prefs'] = array(

--- a/controllers/cron.php
+++ b/controllers/cron.php
@@ -39,8 +39,9 @@ class Cron extends CI_Controller  {
 	function _remap($method)
 	{
 		// check for CRON OR STDIN constants
-		if (php_sapi_name() == 'cli' OR defined('STDIN'))
+		if (php_sapi_name() == 'cli' OR defined('STDIN') OR defined('CRON'))//add CRON for compatibility with cronjobs module
 		{
+            $this->fuel->backup->set_params($this->fuel->backup->config());//set parameters with up to date config/settings...before updating assets flag and download flag....
 			// set assets flag
 			$include_assets = ($method == '1' OR ($method =='index' AND $this->fuel->backup->config('include_assets')));
 			


### PR DESCRIPTION
First off, I continue to find Fuel CMS excellent and hope my small contributions help a little! ->
If ftp fails then script stops and emails etc are not sent. Perhaps better to have ftp default as FALSE, since the other ftp params are empty meaning the ftp will fail. 
Set backup params in cron.php to respect settings/config. Without this patch, only the class config settings are used.
Add CRON constant (defined by the cronjobs module ci_crons.php) to wrapping if statement for compatibility.
